### PR TITLE
Fix sanity check for assigning more grading points than achievable and add uniqueness constraint for Ilias Names

### DIFF
--- a/client/src/components/PointsTextField.tsx
+++ b/client/src/components/PointsTextField.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { TextFieldProps } from '@material-ui/core/TextField';
-import React from 'react';
 import { convertExercisePointInfoToString, ExercisePointsInfo } from 'shared/model/Gradings';
 import FormikTextField from './forms/components/FormikTextField';
 
@@ -38,7 +37,7 @@ function PointsTextField({
       inputProps={{
         min: 0,
         step: 0.1,
-        max: maxPoints,
+        max: maxPoints.total,
         className: classes.input,
       }}
       InputProps={{

--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -110,8 +110,8 @@ export function getInitialStudentFormState({
   const team: string = student
     ? student.team?.id ?? ''
     : teams
-      ? getNextTeamWithSlot(teams, defaultTeamSize)
-      : '';
+    ? getNextTeamWithSlot(teams, defaultTeamSize)
+    : '';
 
   return {
     lastname: student?.lastname ?? '',

--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -110,8 +110,8 @@ export function getInitialStudentFormState({
   const team: string = student
     ? student.team?.id ?? ''
     : teams
-    ? getNextTeamWithSlot(teams, defaultTeamSize)
-    : '';
+      ? getNextTeamWithSlot(teams, defaultTeamSize)
+      : '';
 
   return {
     lastname: student?.lastname ?? '',
@@ -260,6 +260,21 @@ function StudentForm({
           name='iliasName'
           label='Ilias-Name'
           warningLabel='Kein Iliasname eingegeben.'
+          FormikFieldProps={{
+            validate: (value: any) => {
+              if (!value) {
+                return undefined;
+              }
+
+              for (const s of otherStudents) {
+                if (s.iliasName && value === s.iliasName) {
+                  return `Iliasname wird bereits von ${s.nameFirstnameFirst} verwendet.`;
+                }
+              }
+
+              return undefined;
+            },
+          }}
         />
 
         <FormikTextField name='email' label='E-Mailadresse' />


### PR DESCRIPTION
# :ticket: Description
<!-- Describe this PR -->
It is now impossible to assign more points for an exercise than allowed
The problem was that max attribute takes a number and it was provided a ExercisePointsInfo object

The iliasname of a student must be unique now in case it is specified

# :lock: Closes
<!-- Which issue(s) is (are) being closed by the PR? -->
#1025 and #968