### PR TITLE
Feature allow tutors to mark sheets as passed/not passed

### DIFF
--- a/client/src/components/SplitButton.tsx
+++ b/client/src/components/SplitButton.tsx
@@ -41,9 +41,17 @@ interface Props extends ButtonGroupProps {
   initiallySelected?: number;
   variant?: ButtonProps['variant'];
   color?: ButtonProps['color'];
+  onMenuItemClick?: (index: number) => void;
 }
 
-function SplitButton({ options, initiallySelected, variant, color, ...props }: Props): JSX.Element {
+function SplitButton({
+  options,
+  initiallySelected,
+  variant,
+  color,
+  onMenuItemClick,
+  ...props
+}: Props): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLDivElement>(null);
   const logger = useLogger('SplitButton');
@@ -69,6 +77,10 @@ function SplitButton({ options, initiallySelected, variant, color, ...props }: P
   ) => {
     setSelectedIndex(index);
     setOpen(false);
+
+    if (onMenuItemClick) {
+      onMenuItemClick(index);
+    }
   };
 
   const handleToggle = () => {

--- a/client/src/model/Grading.ts
+++ b/client/src/model/Grading.ts
@@ -1,5 +1,5 @@
 import { Transform, Type } from 'class-transformer';
-import { IExerciseGrading, IGrading } from 'shared/model/Gradings';
+import { IExerciseGrading, IGrading, SheetState } from 'shared/model/Gradings';
 import { Modify } from '../typings/Modify';
 import { Exercise, Subexercise } from './Exercise';
 
@@ -60,6 +60,7 @@ export class Grading implements Modify<IGrading, Modified> {
     readonly belongsToTeam!: boolean;
     readonly comment?: string;
     readonly additionalPoints?: number;
+    readonly sheetState?: SheetState;
 
     @Type(() => ExerciseGrading)
     @Transform(({ value }) => new Map(value))

--- a/client/src/pages/points-sheet/enter-form/EnterPoints.helpers.ts
+++ b/client/src/pages/points-sheet/enter-form/EnterPoints.helpers.ts
@@ -89,5 +89,6 @@ export function convertFormStateToGradingDTO({
         createNewGrading: !prevGrading,
         comment: values.comment,
         additionalPoints,
+        sheetState: values.sheetState,
     };
 }

--- a/client/src/pages/points-sheet/enter-form/components/EnterPointsForm.helpers.ts
+++ b/client/src/pages/points-sheet/enter-form/components/EnterPointsForm.helpers.ts
@@ -1,3 +1,4 @@
+import { SheetState } from 'shared/model/Gradings';
 import { Exercise, HasExercises } from '../../../../model/Exercise';
 import { ExerciseGrading, Grading } from '../../../../model/Grading';
 import { FormikSubmitCallback } from '../../../../types';
@@ -17,6 +18,7 @@ export interface PointsFormState {
     exercises: {
         [exerciseId: string]: PointsFormExerciseState;
     };
+    sheetState?: SheetState;
 }
 
 export type PointsFormSubmitCallback = FormikSubmitCallback<PointsFormState>;
@@ -76,5 +78,6 @@ export function generateInitialValues({ sheet, grading }: InitialValuesOptions):
         comment: grading?.comment ?? '',
         additionalPoints: grading?.additionalPoints?.toString() ?? '0',
         exercises,
+        sheetState: grading?.sheetState ? (grading.sheetState ?? SheetState.NO_STATE) : undefined,
     };
 }

--- a/server/src/database/entities/grading.entity.ts
+++ b/server/src/database/entities/grading.entity.ts
@@ -8,7 +8,8 @@ import {
     PrimaryKey,
     Property,
 } from '@mikro-orm/core';
-import { IExerciseGrading, IGrading } from 'shared/model/Gradings';
+import { EncryptedEnumType } from 'database/types/encryption/EncryptedEnumType';
+import { IExerciseGrading, IGrading, SheetState } from 'shared/model/Gradings';
 import { v4 } from 'uuid';
 import { ExerciseGradingDTO, GradingDTO } from '../../module/student/student.dto';
 import { EncryptedMapType } from '../types/encryption/EncryptedMapType';
@@ -107,6 +108,9 @@ export class Grading {
     @ManyToOne(() => ShortTest, { deleteRule: 'cascade' })
     private shortTest?: ShortTest;
 
+    @Property({ type: EncryptedEnumType })
+    sheetState?: SheetState;
+
     @Property({ nullable: false })
     handInId?: string;
 
@@ -172,6 +176,10 @@ export class Grading {
         this.additionalPoints = dto.additionalPoints ?? 0;
         this.exerciseGradings = [];
 
+        if (dto.sheetState) {
+            this.sheetState = dto.sheetState;
+        }
+
         for (const [exerciseId, exerciseGradingDTO] of dto.exerciseGradings) {
             this.exerciseGradings.push(ExerciseGrading.fromDTO(exerciseId, exerciseGradingDTO));
         }
@@ -202,6 +210,7 @@ export class Grading {
             comment: this.comment,
             belongsToTeam: this.belongsToTeam,
             exerciseGradings: [...exerciseGradings],
+            sheetState: this.sheetState,
         };
     }
 

--- a/server/src/module/markdown/markdown.service.ts
+++ b/server/src/module/markdown/markdown.service.ts
@@ -9,6 +9,7 @@ import { Team } from '../../database/entities/team.entity';
 import { ScheinexamService } from '../scheinexam/scheinexam.service';
 import { SheetService } from '../sheet/sheet.service';
 import { ShortTestService } from '../short-test/short-test.service';
+import { GradingService } from '../student/grading.service';
 import { StudentService } from '../student/student.service';
 import { TeamService } from '../team/team.service';
 import {
@@ -23,7 +24,6 @@ import {
     TeamGradings,
     TeamMarkdownData,
 } from './markdown.types';
-import { GradingService } from '../student/grading.service';
 
 @Injectable()
 export class MarkdownService {
@@ -278,7 +278,7 @@ export class MarkdownService {
         });
 
         const totalPointInfo = convertExercisePointInfoToString(pointInfo.total);
-        const header = `# ${nameOfEntity}\n\n**Gesamt: ${pointInfo.achieved} / ${totalPointInfo}**`;
+        const header = `# ${nameOfEntity}${grading.sheetState ? `: ${grading.sheetState}` : ''}\n\n**Gesamt: ${pointInfo.achieved} / ${totalPointInfo}**`;
 
         return `${header}\n\n${exerciseMarkdown}`;
     }

--- a/server/src/module/student/student.dto.ts
+++ b/server/src/module/student/student.dto.ts
@@ -14,7 +14,12 @@ import {
     ValidateNested,
 } from 'class-validator';
 import { AttendanceState, IAttendanceDTO } from 'shared/model/Attendance';
-import { IExerciseGradingDTO, IGradingDTO, IPresentationPointsDTO } from 'shared/model/Gradings';
+import {
+    IExerciseGradingDTO,
+    IGradingDTO,
+    IPresentationPointsDTO,
+    SheetState,
+} from 'shared/model/Gradings';
 import {
     ICakeCountDTO,
     ICreateStudentDTO,
@@ -148,6 +153,10 @@ export class GradingDTO implements IGradingDTO {
     @IsOptional()
     @IsNumber()
     additionalPoints?: number;
+
+    @IsOptional()
+    @IsEnum(SheetState)
+    sheetState?: SheetState;
 }
 
 export class PresentationPointsDTO implements IPresentationPointsDTO {

--- a/server/src/shared/model/Gradings.ts
+++ b/server/src/shared/model/Gradings.ts
@@ -1,5 +1,11 @@
 import { IExercise, IHasExercises } from './HasExercises';
 
+export enum SheetState {
+    PASSED = 'PASSED',
+    NOT_PASSED = 'NOT_PASSED',
+    NO_STATE = 'NO_STATE',
+}
+
 export interface GradingResponseData {
     studentId: string;
     gradingData: IGrading | undefined;
@@ -19,6 +25,7 @@ export interface IGrading {
     points: number;
     comment?: string;
     additionalPoints?: number;
+    sheetState?: SheetState;
 }
 
 export interface IExerciseGradingDTO {
@@ -36,6 +43,7 @@ export interface IGradingDTO {
     shortTestId?: string;
     comment?: string;
     additionalPoints?: number;
+    sheetState?: SheetState;
 }
 
 export interface IPresentationPointsDTO {

--- a/server/src/shared/model/Gradings.ts
+++ b/server/src/shared/model/Gradings.ts
@@ -1,9 +1,9 @@
 import { IExercise, IHasExercises } from './HasExercises';
 
 export enum SheetState {
-    PASSED = 'PASSED',
-    NOT_PASSED = 'NOT_PASSED',
-    NO_STATE = 'NO_STATE',
+    PASSED = 'Bestanden',
+    NOT_PASSED = 'Nicht bestanden',
+    NO_STATE = 'Nicht bewertet',
 }
 
 export interface GradingResponseData {


### PR DESCRIPTION
# :ticket: Description
<!-- Describe this PR -->
Allow tutors to mark a sheet as passed/not passed or not mark at all.
This doesn't have any implications on scheincriteria calculation.
The status will be printed to the PDF as follows "Bestanden" and "Nicht bestanden"

# :lock: Closes
<!-- Which issue(s) is (are) being closed by the PR? -->
#162 